### PR TITLE
Removed deprecated Modules/FluidProperties syntax

### DIFF
--- a/doc/content/source/fluidproperties/SodiumLiquidFluidProperties.md
+++ b/doc/content/source/fluidproperties/SodiumLiquidFluidProperties.md
@@ -1,9 +1,9 @@
 # SodiumLiquidFluidProperties
 
-!syntax description /Modules/FluidProperties/SodiumLiquidFluidProperties
+!syntax description /FluidProperties/SodiumLiquidFluidProperties
 
-!syntax parameters /Modules/FluidProperties/SodiumLiquidFluidProperties
+!syntax parameters /FluidProperties/SodiumLiquidFluidProperties
 
-!syntax inputs /Modules/FluidProperties/SodiumLiquidFluidProperties
+!syntax inputs /FluidProperties/SodiumLiquidFluidProperties
 
-!syntax children /Modules/FluidProperties/SodiumLiquidFluidProperties
+!syntax children /FluidProperties/SodiumLiquidFluidProperties

--- a/doc/content/source/fluidproperties/SodiumTwoPhaseFluidProperties.md
+++ b/doc/content/source/fluidproperties/SodiumTwoPhaseFluidProperties.md
@@ -1,9 +1,9 @@
 # SodiumTwoPhaseFluidProperties
 
-!syntax description /Modules/FluidProperties/SodiumTwoPhaseFluidProperties
+!syntax description /FluidProperties/SodiumTwoPhaseFluidProperties
 
-!syntax parameters /Modules/FluidProperties/SodiumTwoPhaseFluidProperties
+!syntax parameters /FluidProperties/SodiumTwoPhaseFluidProperties
 
-!syntax inputs /Modules/FluidProperties/SodiumTwoPhaseFluidProperties
+!syntax inputs /FluidProperties/SodiumTwoPhaseFluidProperties
 
-!syntax children /Modules/FluidProperties/SodiumTwoPhaseFluidProperties
+!syntax children /FluidProperties/SodiumTwoPhaseFluidProperties

--- a/doc/content/source/fluidproperties/SodiumVaporFluidProperties.md
+++ b/doc/content/source/fluidproperties/SodiumVaporFluidProperties.md
@@ -1,9 +1,9 @@
 # SodiumVaporFluidProperties
 
-!syntax description /Modules/FluidProperties/SodiumVaporFluidProperties
+!syntax description /FluidProperties/SodiumVaporFluidProperties
 
-!syntax parameters /Modules/FluidProperties/SodiumVaporFluidProperties
+!syntax parameters /FluidProperties/SodiumVaporFluidProperties
 
-!syntax inputs /Modules/FluidProperties/SodiumVaporFluidProperties
+!syntax inputs /FluidProperties/SodiumVaporFluidProperties
 
-!syntax children /Modules/FluidProperties/SodiumVaporFluidProperties
+!syntax children /FluidProperties/SodiumVaporFluidProperties


### PR DESCRIPTION
Refs [idaholab/moose#22093](https://github.com/idaholab/moose/issues/22093)